### PR TITLE
Prévention des doubles soumissions de vols de découverte

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -24,7 +24,7 @@ if (! defined('BASEPATH')) exit('No direct script access allowed');
 
 $config['migration_enabled'] = true;
 
-$config['migration_version'] = 103;
+$config['migration_version'] = 104;
 
 /* End of file migration.php */
 /* Location: .application/config/migration.php */

--- a/application/controllers/vols_decouverte.php
+++ b/application/controllers/vols_decouverte.php
@@ -1217,7 +1217,10 @@ EOD;
             return;
         }
 
-        $this->_render_public_vd($section_id, $section_row, $sections_disponibles, $section_error);
+        // PRG: restore errors and form data from a failed POST redirect
+        $errors    = (array) ($this->session->flashdata('vd_public_errors')    ?: array());
+        $form_data = (array) ($this->session->flashdata('vd_public_form_data') ?: array());
+        $this->_render_public_vd($section_id, $section_row, $sections_disponibles, $section_error, $errors, null, $form_data);
     }
 
     /**
@@ -1226,10 +1229,9 @@ EOD;
     private function _post_public_vd($section_id, $section_row, array $sections_disponibles) {
         // Rate limiting
         if (!check_rate_limit('vd_public_form', 10, 3600)) {
-            $this->_render_public_vd(
-                $section_id, $section_row, $sections_disponibles, '',
-                array('rate_limit' => $this->lang->line('gvv_vd_public_rate_limit'))
-            );
+            $this->session->set_flashdata('vd_public_errors',
+                array('rate_limit' => $this->lang->line('gvv_vd_public_rate_limit')));
+            redirect('vols_decouverte/public_vd' . ($section_id > 0 ? '?section=' . $section_id : ''));
             return;
         }
 
@@ -1237,10 +1239,8 @@ EOD;
         if ($section_id > 0) {
             $quota_status = get_vd_quota_status($section_id);
             if ($quota_status['atteint']) {
-                $this->_render_public_vd(
-                    $section_id, $section_row, $sections_disponibles, '',
-                    array(), $quota_status
-                );
+                // Redirect to GET — quota state is re-detected naturally by _render_public_vd
+                redirect('vols_decouverte/public_vd' . ($section_id > 0 ? '?section=' . $section_id : ''));
                 return;
             }
         }
@@ -1321,7 +1321,9 @@ EOD;
         }
 
         if (!empty($errors)) {
-            $this->_render_public_vd($section_id, $section_row, $sections_disponibles, '', $errors, null, $form_data);
+            $this->session->set_flashdata('vd_public_errors', $errors);
+            $this->session->set_flashdata('vd_public_form_data', $form_data);
+            redirect('vols_decouverte/public_vd' . ($section_id > 0 ? '?section=' . $section_id : ''));
             return;
         }
 
@@ -1329,7 +1331,9 @@ EOD;
         $enabled = $this->paiements_en_ligne_model->get_config('helloasso', 'enabled', $section_id);
         if ($enabled !== '1') {
             $errors['general'] = $this->lang->line('gvv_vd_public_section_disabled');
-            $this->_render_public_vd($section_id, $section_row, $sections_disponibles, '', $errors, null, $form_data);
+            $this->session->set_flashdata('vd_public_errors', $errors);
+            $this->session->set_flashdata('vd_public_form_data', $form_data);
+            redirect('vols_decouverte/public_vd' . ($section_id > 0 ? '?section=' . $section_id : ''));
             return;
         }
 

--- a/application/controllers/vols_decouverte.php
+++ b/application/controllers/vols_decouverte.php
@@ -1239,7 +1239,8 @@ EOD;
         if ($section_id > 0) {
             $quota_status = get_vd_quota_status($section_id);
             if ($quota_status['atteint']) {
-                // Redirect to GET — quota state is re-detected naturally by _render_public_vd
+                $this->session->set_flashdata('vd_public_errors',
+                    array('quota' => $this->lang->line('gvv_vd_quota_erreur_post')));
                 redirect('vols_decouverte/public_vd' . ($section_id > 0 ? '?section=' . $section_id : ''));
                 return;
             }

--- a/application/migrations/104_vols_decouverte_unique_submit.php
+++ b/application/migrations/104_vols_decouverte_unique_submit.php
@@ -1,0 +1,43 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/**
+ * Migration 104 — Contrainte UNIQUE anti-doublon sur vols_decouverte
+ *
+ * Un double-clic sur un réseau lent peut soumettre deux fois le même formulaire
+ * et créer deux enregistrements identiques.  Cette contrainte sur (club, date_vente,
+ * beneficiaire, product) bloque l'insertion du second doublon au niveau base de données.
+ * La contrainte s'appuie sur l'erreur MySQL 1062 déjà gérée par Gvv_Controller
+ * avec un message utilisateur propre.
+ *
+ * Si des doublons existent déjà dans la base la migration est ignorée (log d'erreur)
+ * afin de ne pas bloquer le déploiement.
+ */
+class Migration_Vols_decouverte_unique_submit extends CI_Migration {
+
+    public function up() {
+        $result = $this->db->query(
+            "SELECT COUNT(*) AS cnt FROM (
+                SELECT club, date_vente, beneficiaire, product, COUNT(*) AS n
+                FROM vols_decouverte
+                GROUP BY club, date_vente, beneficiaire, product
+                HAVING n > 1
+            ) t"
+        )->row_array();
+
+        if ((int) $result['cnt'] > 0) {
+            log_message('error',
+                'Migration 104: cannot add UNIQUE constraint on vols_decouverte — '
+                . $result['cnt'] . ' duplicate group(s) exist. Run manually after deduplication.');
+            return;
+        }
+
+        $this->db->query(
+            "ALTER TABLE vols_decouverte
+             ADD UNIQUE KEY uk_vd_no_double_submit (club, date_vente, beneficiaire, product)"
+        );
+    }
+
+    public function down() {
+        $this->db->query("ALTER TABLE vols_decouverte DROP INDEX uk_vd_no_double_submit");
+    }
+}

--- a/application/migrations/104_vols_decouverte_unique_submit.php
+++ b/application/migrations/104_vols_decouverte_unique_submit.php
@@ -38,6 +38,6 @@ class Migration_Vols_decouverte_unique_submit extends CI_Migration {
     }
 
     public function down() {
-        $this->db->query("ALTER TABLE vols_decouverte DROP INDEX uk_vd_no_double_submit");
+        $this->db->query("ALTER TABLE vols_decouverte DROP INDEX IF EXISTS uk_vd_no_double_submit");
     }
 }

--- a/application/views/bs_footer.php
+++ b/application/views/bs_footer.php
@@ -17,9 +17,12 @@ if ($banner_color === '') {
 <script type="text/javascript">
     <!--
     $(document).ready(function() {
-        // Prevent double-submission on slow networks: disable submit buttons after first click
+        // Prevent double-submission on slow networks: disable submit buttons after first click.
+        // setTimeout defers the disable until after the browser has collected form data,
+        // so named submit buttons (name="button") are still included in the POST payload.
         $('form').on('submit', function() {
-            $(this).find('button[type="submit"], input[type="submit"]').prop('disabled', true);
+            var $btns = $(this).find('button[type="submit"], input[type="submit"]');
+            setTimeout(function() { $btns.prop('disabled', true); }, 0);
         });
 
         // notre code ici

--- a/application/views/bs_footer.php
+++ b/application/views/bs_footer.php
@@ -17,6 +17,11 @@ if ($banner_color === '') {
 <script type="text/javascript">
     <!--
     $(document).ready(function() {
+        // Prevent double-submission on slow networks: disable submit buttons after first click
+        $('form').on('submit', function() {
+            $(this).find('button[type="submit"], input[type="submit"]').prop('disabled', true);
+        });
+
         // notre code ici
         $(".jbutton").button();
         $("#tabs").tabs();


### PR DESCRIPTION
## Résumé

- **JS (bs_footer.php)** : désactivation des boutons submit après le premier clic pour prévenir la double soumission sur réseaux lents. Utilise `setTimeout(fn, 0)` pour différer le disable après la sérialisation des données du formulaire (évite d'exclure `name="button"` du POST).
- **Migration 104** : contrainte `UNIQUE KEY uk_vd_no_double_submit (club, date_vente, beneficiaire, product)` sur `vols_decouverte` comme filet de sécurité niveau base de données. La migration vérifie l'absence de doublons avant d'appliquer la contrainte.
- **PRG pattern (vols_decouverte.php)** : Post-Redirect-Get sur les erreurs du formulaire public `public_vd` — empêche le navigateur de proposer "renvoyer le formulaire" après un rechargement de page.

## Plan de test

- [x] Vérifier que le formulaire public de vols de découverte affiche les erreurs de validation après soumission invalide
- [ ] Vérifier que les données du formulaire sont bien conservées après une erreur (champ bénéficiaire, etc.)
- [ ] Vérifier que la soumission valide crée bien un vol de découverte
- [ ] Vérifier que les boutons submit sont bien désactivés visuellement après le premier clic
- [ ] Vérifier que les formulaires internes (vol avion, écriture comptable) fonctionnent normalement
- [ ] Suite Playwright : `npx playwright test` — seul `vols-decouverte-public.spec.js:249` (qrcode ID 4, donnée de test manquante) reste en échec pré-existant

🤖 Generated with [Claude Code](https://claude.com/claude-code)