### PR TITLE
Rapports de formation : heures DC volsa, export PDF annuel, filtrage par section

### DIFF
--- a/application/controllers/formation_rapports.php
+++ b/application/controllers/formation_rapports.php
@@ -21,6 +21,8 @@
  * @package controllers
  */
 
+include_once(APPPATH . '/third_party/tcpdf/tcpdf.php');
+
 class Formation_rapports extends MY_Controller
 {
     protected $controller = 'formation_rapports';
@@ -42,6 +44,7 @@ class Formation_rapports extends MY_Controller
         $this->load->helper('validation');
         $this->lang->load('formation');
         $this->lang->load('gvv');
+        $this->lang->load('sections');
 
         // Bouton retour → tableau de bord Formation
         $this->lang->load('tableaux_de_bord');
@@ -49,6 +52,18 @@ class Formation_rapports extends MY_Controller
             'nav_back_url'   => $this->session->userdata('nav_from_url')   ?: 'welcome/section/formation',
             'nav_back_label' => $this->session->userdata('nav_from_label') ?: $this->lang->line('db_section_training'),
         ]);
+    }
+
+    /**
+     * Libellé de la section actuellement active (sélecteur du menu), ou
+     * "Toutes" si aucune section spécifique n'est sélectionnée.
+     *
+     * @return string
+     */
+    private function _section_active_label()
+    {
+        $section = $this->formation_seance_model->section();
+        return $section ? $section['nom'] : $this->lang->line('all_sections');
     }
 
     /**
@@ -157,7 +172,8 @@ class Formation_rapports extends MY_Controller
             'stats_par_categorie' => $stats_par_categorie,
             'stats_dc_instructeur' => $stats_dc_instructeur,
             'stats_dc_machine' => $stats_dc_machine,
-            'formation_progression' => $this->formation_progression
+            'formation_progression' => $this->formation_progression,
+            'section_active_label' => $this->_section_active_label(),
         );
 
         $this->load->view('formation_rapports/index', $data);
@@ -197,12 +213,13 @@ class Formation_rapports extends MY_Controller
         $stats_programmes   = $this->formation_seance_model->get_stats_annuels_par_programme($year);
 
         $data = array(
-            'title'              => $this->lang->line('formation_rapports_annuel_title'),
-            'controller'         => $this->controller,
-            'year'               => $year,
-            'year_selector'      => $year_selector,
-            'stats_instructeurs' => $stats_instructeurs,
-            'stats_programmes'   => $stats_programmes,
+            'title'                => $this->lang->line('formation_rapports_annuel_title'),
+            'controller'           => $this->controller,
+            'year'                 => $year,
+            'year_selector'        => $year_selector,
+            'stats_instructeurs'   => $stats_instructeurs,
+            'stats_programmes'     => $stats_programmes,
+            'section_active_label' => $this->_section_active_label(),
         );
 
         $this->load->view('formation_rapports/annuel', $data);
@@ -283,6 +300,304 @@ class Formation_rapports extends MY_Controller
         }
 
         csv_file($title, $rows);
+    }
+
+    /**
+     * Export PDF du rapport annuel consolidé (par instructeur et par programme).
+     *
+     * @param int $year
+     */
+    public function export_annuel_pdf($year = null)
+    {
+        if (empty($year)) {
+            $year = $this->session->userdata('year') ?: date('Y');
+        }
+        $year = (int) $year;
+
+        $stats_instructeurs = $this->formation_seance_model->get_stats_annuels_par_instructeur($year);
+        $stats_programmes   = $this->formation_seance_model->get_stats_annuels_par_programme($year);
+
+        // Listes de formations (mêmes données/colonnes que formation_rapports/index)
+        $formations = $this->formation_inscription_model->get_by_year($year);
+        $date_limite = $year . '-12-31';
+        foreach ($formations['en_cours'] as &$inscription) {
+            $inscription['progression'] = $this->formation_progression->calculer_pourcentage_a_date(
+                $inscription['id'], $date_limite
+            );
+        }
+        unset($inscription);
+
+        $nom_club = $this->config->item('nom_club');
+        $title    = $this->lang->line('formation_rapports_annuel_title') . ' ' . $year;
+
+        $html = '<p style="text-align:right;color:#555;font-size:9pt;">' . htmlspecialchars($nom_club) . '</p>';
+        $html .= '<h1>' . htmlspecialchars($title) . '</h1>';
+        $html .= '<p style="font-size:9pt;color:#777;">'
+            . $this->lang->line('formation_rapports_annuel_genere_le') . ' ' . date('d/m/Y H:i')
+            . ' — ' . $this->lang->line('formation_rapports_section_active') . ' : '
+            . htmlspecialchars($this->_section_active_label())
+            . '</p>';
+        $html .= '<hr>';
+
+        // Clôturées avec succès
+        $rows = array();
+        foreach ($formations['cloturees'] as $f) {
+            $rows[] = array(
+                htmlspecialchars(trim(($f['pilote_prenom'] ?? '') . ' ' . ($f['pilote_nom'] ?? ''))),
+                htmlspecialchars($f['programme_titre'] ?? ''),
+                htmlspecialchars(trim(($f['instructeur_prenom'] ?? '') . ' ' . ($f['instructeur_nom'] ?? ''))),
+                !empty($f['date_cloture']) ? date('d/m/Y', strtotime($f['date_cloture'])) : '-',
+            );
+        }
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_cloturees_succes') . ' (' . count($formations['cloturees']) . ')',
+            array(
+                $this->lang->line('formation_inscription_pilote'),
+                $this->lang->line('formation_inscription_programme'),
+                $this->lang->line('formation_inscription_instructeur'),
+                $this->lang->line('formation_rapports_date_cloture'),
+            ),
+            $rows
+        );
+
+        // Abandonnées
+        $rows = array();
+        foreach ($formations['abandonnees'] as $f) {
+            $rows[] = array(
+                htmlspecialchars(trim(($f['pilote_prenom'] ?? '') . ' ' . ($f['pilote_nom'] ?? ''))),
+                htmlspecialchars($f['programme_titre'] ?? ''),
+                !empty($f['date_cloture']) ? date('d/m/Y', strtotime($f['date_cloture'])) : '-',
+                htmlspecialchars($f['motif_cloture'] ?? ''),
+            );
+        }
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_abandonnees') . ' (' . count($formations['abandonnees']) . ')',
+            array(
+                $this->lang->line('formation_inscription_pilote'),
+                $this->lang->line('formation_inscription_programme'),
+                $this->lang->line('formation_rapports_date_cloture'),
+                $this->lang->line('formation_rapports_motif'),
+            ),
+            $rows
+        );
+
+        // Suspendues
+        $rows = array();
+        foreach ($formations['suspendues'] as $f) {
+            $rows[] = array(
+                htmlspecialchars(trim(($f['pilote_prenom'] ?? '') . ' ' . ($f['pilote_nom'] ?? ''))),
+                htmlspecialchars($f['programme_titre'] ?? ''),
+                !empty($f['date_suspension']) ? date('d/m/Y', strtotime($f['date_suspension'])) : '-',
+                htmlspecialchars($f['motif_suspension'] ?? ''),
+            );
+        }
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_suspendues') . ' (' . count($formations['suspendues']) . ')',
+            array(
+                $this->lang->line('formation_inscription_pilote'),
+                $this->lang->line('formation_inscription_programme'),
+                $this->lang->line('formation_rapports_date_suspension'),
+                $this->lang->line('formation_rapports_motif'),
+            ),
+            $rows
+        );
+
+        // Ouvertes dans l'année
+        $rows = array();
+        foreach ($formations['ouvertes'] as $f) {
+            $rows[] = array(
+                htmlspecialchars(trim(($f['pilote_prenom'] ?? '') . ' ' . ($f['pilote_nom'] ?? ''))),
+                htmlspecialchars($f['programme_titre'] ?? ''),
+                htmlspecialchars(trim(($f['instructeur_prenom'] ?? '') . ' ' . ($f['instructeur_nom'] ?? ''))),
+                !empty($f['date_ouverture']) ? date('d/m/Y', strtotime($f['date_ouverture'])) : '-',
+                htmlspecialchars($this->lang->line('formation_inscription_statut_' . $f['statut'])),
+            );
+        }
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_ouvertes') . ' (' . count($formations['ouvertes']) . ')',
+            array(
+                $this->lang->line('formation_inscription_pilote'),
+                $this->lang->line('formation_inscription_programme'),
+                $this->lang->line('formation_inscription_instructeur'),
+                $this->lang->line('formation_inscription_date_ouverture'),
+                $this->lang->line('formation_inscription_statut'),
+            ),
+            $rows
+        );
+
+        // En cours (avec progression)
+        $rows = array();
+        foreach ($formations['en_cours'] as $f) {
+            $pct = isset($f['progression']) ? $f['progression']['pourcentage'] : 0;
+            $rows[] = array(
+                htmlspecialchars(trim(($f['pilote_prenom'] ?? '') . ' ' . ($f['pilote_nom'] ?? ''))),
+                htmlspecialchars($f['programme_titre'] ?? ''),
+                htmlspecialchars(trim(($f['instructeur_prenom'] ?? '') . ' ' . ($f['instructeur_nom'] ?? ''))),
+                !empty($f['date_ouverture']) ? date('d/m/Y', strtotime($f['date_ouverture'])) : '-',
+                $pct . ' %',
+            );
+        }
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_en_cours') . ' (' . count($formations['en_cours']) . ')',
+            array(
+                $this->lang->line('formation_inscription_pilote'),
+                $this->lang->line('formation_inscription_programme'),
+                $this->lang->line('formation_inscription_instructeur'),
+                $this->lang->line('formation_inscription_date_ouverture'),
+                $this->lang->line('formation_rapports_progression'),
+            ),
+            $rows
+        );
+
+        $html .= '<hr>';
+
+        // Par instructeur
+        $html .= '<div style="page-break-inside:avoid;">';
+        $html .= '<h2>' . $this->lang->line('formation_rapports_annuel_par_instructeur') . '</h2>';
+        $html .= '<table border="1" cellpadding="3" cellspacing="0" style="width:100%;font-size:8pt;">';
+        $html .= '<tr style="background-color:#eee;">'
+            . '<th>' . $this->lang->line('formation_inscription_instructeur') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_vol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_vol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_eleves_vol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_sol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_sol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_eleves_sol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_nb_seances') . '</th>'
+            . '</tr>';
+
+        $tot_sv = $tot_hv = $tot_ev = $tot_ss = $tot_hs = $tot_es = $tot_t = 0;
+        foreach ($stats_instructeurs as $s) {
+            $total   = $s['nb_seances_vol'] + $s['nb_seances_sol'];
+            $tot_sv += $s['nb_seances_vol'];
+            $tot_hv += $s['heures_vol'];
+            $tot_ev += $s['nb_eleves_vol'];
+            $tot_ss += $s['nb_seances_sol'];
+            $tot_hs += $s['heures_sol'];
+            $tot_es += $s['nb_eleves_sol'];
+            $tot_t  += $total;
+
+            $html .= '<tr>'
+                . '<td>' . htmlspecialchars(trim($s['prenom'] . ' ' . $s['nom'])) . '</td>'
+                . '<td align="center">' . ($s['nb_seances_vol'] ?: '-') . '</td>'
+                . '<td align="center">' . ($s['heures_vol'] > 0 ? number_format($s['heures_vol'], 1, ',', '') . ' h' : '-') . '</td>'
+                . '<td align="center">' . ($s['nb_eleves_vol'] ?: '-') . '</td>'
+                . '<td align="center">' . ($s['nb_seances_sol'] ?: '-') . '</td>'
+                . '<td align="center">' . ($s['heures_sol'] > 0 ? number_format($s['heures_sol'], 1, ',', '') . ' h' : '-') . '</td>'
+                . '<td align="center">' . ($s['nb_eleves_sol'] ?: '-') . '</td>'
+                . '<td align="center"><b>' . $total . '</b></td>'
+                . '</tr>';
+        }
+        $html .= '<tr style="background-color:#eee;">'
+            . '<th>' . $this->lang->line('gvv_total') . '</th>'
+            . '<th>' . $tot_sv . '</th>'
+            . '<th>' . number_format($tot_hv, 1, ',', '') . ' h</th>'
+            . '<th>' . $tot_ev . '</th>'
+            . '<th>' . $tot_ss . '</th>'
+            . '<th>' . number_format($tot_hs, 1, ',', '') . ' h</th>'
+            . '<th>' . $tot_es . '</th>'
+            . '<th>' . $tot_t . '</th>'
+            . '</tr>';
+        $html .= '</table>';
+        $html .= '</div>';
+
+        // Par programme
+        $html .= '<div style="page-break-inside:avoid;">';
+        $html .= '<h2>' . $this->lang->line('formation_rapports_annuel_par_programme') . '</h2>';
+        $html .= '<table border="1" cellpadding="3" cellspacing="0" style="width:100%;font-size:8pt;">';
+        $html .= '<tr style="background-color:#eee;">'
+            . '<th>' . $this->lang->line('formation_seance_programme') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_vol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_vol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_sol') . '</th>'
+            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_sol') . '</th>'
+            . '</tr>';
+
+        $tot_p_sv = $tot_p_hv = $tot_p_ss = $tot_p_hs = 0;
+        foreach ($stats_programmes as $p) {
+            $tot_p_sv += $p['nb_seances_vol'];
+            $tot_p_hv += $p['heures_vol'];
+            $tot_p_ss += $p['nb_seances_sol'];
+            $tot_p_hs += $p['heures_sol'];
+
+            $html .= '<tr>'
+                . '<td>' . htmlspecialchars($p['programme_titre']) . '</td>'
+                . '<td align="center">' . ($p['nb_seances_vol'] ?: '-') . '</td>'
+                . '<td align="center">' . ($p['heures_vol'] > 0 ? number_format($p['heures_vol'], 1, ',', '') . ' h' : '-') . '</td>'
+                . '<td align="center">' . ($p['nb_seances_sol'] ?: '-') . '</td>'
+                . '<td align="center">' . ($p['heures_sol'] > 0 ? number_format($p['heures_sol'], 1, ',', '') . ' h' : '-') . '</td>'
+                . '</tr>';
+        }
+        $html .= '<tr style="background-color:#eee;">'
+            . '<th>' . $this->lang->line('gvv_total') . '</th>'
+            . '<th>' . $tot_p_sv . '</th>'
+            . '<th>' . number_format($tot_p_hv, 1, ',', '') . ' h</th>'
+            . '<th>' . $tot_p_ss . '</th>'
+            . '<th>' . number_format($tot_p_hs, 1, ',', '') . ' h</th>'
+            . '</tr>';
+        $html .= '</table>';
+        $html .= '</div>';
+
+        $pdf = new TCPDF('L', 'mm', 'A4', true, 'UTF-8', false);
+        $pdf->SetCreator($nom_club);
+        $pdf->SetAuthor($nom_club);
+        $pdf->SetTitle($title);
+        $pdf->SetSubject($this->lang->line('formation_rapports_annuel_title'));
+
+        $pdf->setPrintHeader(false);
+        $pdf->setPrintFooter(false);
+        $pdf->SetMargins(15, 15, 15);
+        $pdf->SetAutoPageBreak(true, 15);
+
+        $pdf->AddPage();
+        $pdf->SetFont('helvetica', '', 10);
+        $pdf->writeHTML($html, true, false, true, false, '');
+
+        $filename = 'rapport_annuel_formation_' . $year . '.pdf';
+        $pdf->Output($filename, 'I');
+        exit;
+    }
+
+    /**
+     * Génère le HTML d'un tableau de section pour export_annuel_pdf()
+     * (cellules déjà formatées/échappées par l'appelant).
+     *
+     * @param string $title   Titre de section (avec effectif entre parenthèses)
+     * @param array  $headers En-têtes de colonnes
+     * @param array  $rows    Lignes, chacune un tableau de cellules HTML
+     * @return string
+     */
+    private function _pdf_section_table($title, array $headers, array $rows)
+    {
+        // page-break-inside:avoid pousse tout le bloc (titre + tableau) sur la
+        // page suivante s'il ne tient pas dans l'espace restant, pour ne
+        // jamais laisser le titre seul en bas de page.
+        $html = '<div style="page-break-inside:avoid;">';
+        $html .= '<h2>' . htmlspecialchars($title) . '</h2>';
+
+        if (empty($rows)) {
+            $html .= '<p style="font-size:8pt;color:#777;">' . $this->lang->line('formation_rapports_aucune') . '</p>';
+            $html .= '</div>';
+            return $html;
+        }
+
+        $html .= '<table border="1" cellpadding="3" cellspacing="0" style="width:100%;font-size:8pt;">';
+        $html .= '<tr style="background-color:#eee;">';
+        foreach ($headers as $h) {
+            $html .= '<th>' . htmlspecialchars($h) . '</th>';
+        }
+        $html .= '</tr>';
+        foreach ($rows as $row) {
+            $html .= '<tr>';
+            foreach ($row as $cell) {
+                $html .= '<td>' . $cell . '</td>';
+            }
+            $html .= '</tr>';
+        }
+        $html .= '</table>';
+        $html .= '</div>';
+
+        return $html;
     }
 
     /**

--- a/application/controllers/formation_rapports.php
+++ b/application/controllers/formation_rapports.php
@@ -452,20 +452,7 @@ class Formation_rapports extends MY_Controller
         $html .= '<hr>';
 
         // Par instructeur
-        $html .= '<div style="page-break-inside:avoid;">';
-        $html .= '<h2>' . $this->lang->line('formation_rapports_annuel_par_instructeur') . '</h2>';
-        $html .= '<table border="1" cellpadding="3" cellspacing="0" style="width:100%;font-size:8pt;">';
-        $html .= '<tr style="background-color:#eee;">'
-            . '<th>' . $this->lang->line('formation_inscription_instructeur') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_vol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_vol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_eleves_vol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_sol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_sol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_eleves_sol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_nb_seances') . '</th>'
-            . '</tr>';
-
+        $rows = array();
         $tot_sv = $tot_hv = $tot_ev = $tot_ss = $tot_hs = $tot_es = $tot_t = 0;
         foreach ($stats_instructeurs as $s) {
             $total   = $s['nb_seances_vol'] + $s['nb_seances_sol'];
@@ -477,42 +464,45 @@ class Formation_rapports extends MY_Controller
             $tot_es += $s['nb_eleves_sol'];
             $tot_t  += $total;
 
-            $html .= '<tr>'
-                . '<td>' . htmlspecialchars(trim($s['prenom'] . ' ' . $s['nom'])) . '</td>'
-                . '<td align="center">' . ($s['nb_seances_vol'] ?: '-') . '</td>'
-                . '<td align="center">' . ($s['heures_vol'] > 0 ? number_format($s['heures_vol'], 1, ',', '') . ' h' : '-') . '</td>'
-                . '<td align="center">' . ($s['nb_eleves_vol'] ?: '-') . '</td>'
-                . '<td align="center">' . ($s['nb_seances_sol'] ?: '-') . '</td>'
-                . '<td align="center">' . ($s['heures_sol'] > 0 ? number_format($s['heures_sol'], 1, ',', '') . ' h' : '-') . '</td>'
-                . '<td align="center">' . ($s['nb_eleves_sol'] ?: '-') . '</td>'
-                . '<td align="center"><b>' . $total . '</b></td>'
-                . '</tr>';
+            $rows[] = array(
+                htmlspecialchars(trim($s['prenom'] . ' ' . $s['nom'])),
+                $s['nb_seances_vol'] ?: '-',
+                $s['heures_vol'] > 0 ? number_format($s['heures_vol'], 1, ',', '') . ' h' : '-',
+                $s['nb_eleves_vol'] ?: '-',
+                $s['nb_seances_sol'] ?: '-',
+                $s['heures_sol'] > 0 ? number_format($s['heures_sol'], 1, ',', '') . ' h' : '-',
+                $s['nb_eleves_sol'] ?: '-',
+                '<b>' . $total . '</b>',
+            );
         }
-        $html .= '<tr style="background-color:#eee;">'
-            . '<th>' . $this->lang->line('gvv_total') . '</th>'
-            . '<th>' . $tot_sv . '</th>'
-            . '<th>' . number_format($tot_hv, 1, ',', '') . ' h</th>'
-            . '<th>' . $tot_ev . '</th>'
-            . '<th>' . $tot_ss . '</th>'
-            . '<th>' . number_format($tot_hs, 1, ',', '') . ' h</th>'
-            . '<th>' . $tot_es . '</th>'
-            . '<th>' . $tot_t . '</th>'
-            . '</tr>';
-        $html .= '</table>';
-        $html .= '</div>';
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_annuel_par_instructeur'),
+            array(
+                $this->lang->line('formation_inscription_instructeur'),
+                $this->lang->line('formation_rapports_annuel_nb_seances_vol'),
+                $this->lang->line('formation_rapports_annuel_heures_vol'),
+                $this->lang->line('formation_rapports_annuel_nb_eleves_vol'),
+                $this->lang->line('formation_rapports_annuel_nb_seances_sol'),
+                $this->lang->line('formation_rapports_annuel_heures_sol'),
+                $this->lang->line('formation_rapports_annuel_nb_eleves_sol'),
+                $this->lang->line('formation_rapports_nb_seances'),
+            ),
+            $rows,
+            array(
+                $this->lang->line('gvv_total'),
+                $tot_sv,
+                number_format($tot_hv, 1, ',', '') . ' h',
+                $tot_ev,
+                $tot_ss,
+                number_format($tot_hs, 1, ',', '') . ' h',
+                $tot_es,
+                $tot_t,
+            ),
+            array('left', 'center', 'center', 'center', 'center', 'center', 'center', 'center')
+        );
 
         // Par programme
-        $html .= '<div style="page-break-inside:avoid;">';
-        $html .= '<h2>' . $this->lang->line('formation_rapports_annuel_par_programme') . '</h2>';
-        $html .= '<table border="1" cellpadding="3" cellspacing="0" style="width:100%;font-size:8pt;">';
-        $html .= '<tr style="background-color:#eee;">'
-            . '<th>' . $this->lang->line('formation_seance_programme') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_vol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_vol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_nb_seances_sol') . '</th>'
-            . '<th>' . $this->lang->line('formation_rapports_annuel_heures_sol') . '</th>'
-            . '</tr>';
-
+        $rows = array();
         $tot_p_sv = $tot_p_hv = $tot_p_ss = $tot_p_hs = 0;
         foreach ($stats_programmes as $p) {
             $tot_p_sv += $p['nb_seances_vol'];
@@ -520,23 +510,33 @@ class Formation_rapports extends MY_Controller
             $tot_p_ss += $p['nb_seances_sol'];
             $tot_p_hs += $p['heures_sol'];
 
-            $html .= '<tr>'
-                . '<td>' . htmlspecialchars($p['programme_titre']) . '</td>'
-                . '<td align="center">' . ($p['nb_seances_vol'] ?: '-') . '</td>'
-                . '<td align="center">' . ($p['heures_vol'] > 0 ? number_format($p['heures_vol'], 1, ',', '') . ' h' : '-') . '</td>'
-                . '<td align="center">' . ($p['nb_seances_sol'] ?: '-') . '</td>'
-                . '<td align="center">' . ($p['heures_sol'] > 0 ? number_format($p['heures_sol'], 1, ',', '') . ' h' : '-') . '</td>'
-                . '</tr>';
+            $rows[] = array(
+                htmlspecialchars($p['programme_titre']),
+                $p['nb_seances_vol'] ?: '-',
+                $p['heures_vol'] > 0 ? number_format($p['heures_vol'], 1, ',', '') . ' h' : '-',
+                $p['nb_seances_sol'] ?: '-',
+                $p['heures_sol'] > 0 ? number_format($p['heures_sol'], 1, ',', '') . ' h' : '-',
+            );
         }
-        $html .= '<tr style="background-color:#eee;">'
-            . '<th>' . $this->lang->line('gvv_total') . '</th>'
-            . '<th>' . $tot_p_sv . '</th>'
-            . '<th>' . number_format($tot_p_hv, 1, ',', '') . ' h</th>'
-            . '<th>' . $tot_p_ss . '</th>'
-            . '<th>' . number_format($tot_p_hs, 1, ',', '') . ' h</th>'
-            . '</tr>';
-        $html .= '</table>';
-        $html .= '</div>';
+        $html .= $this->_pdf_section_table(
+            $this->lang->line('formation_rapports_annuel_par_programme'),
+            array(
+                $this->lang->line('formation_seance_programme'),
+                $this->lang->line('formation_rapports_annuel_nb_seances_vol'),
+                $this->lang->line('formation_rapports_annuel_heures_vol'),
+                $this->lang->line('formation_rapports_annuel_nb_seances_sol'),
+                $this->lang->line('formation_rapports_annuel_heures_sol'),
+            ),
+            $rows,
+            array(
+                $this->lang->line('gvv_total'),
+                $tot_p_sv,
+                number_format($tot_p_hv, 1, ',', '') . ' h',
+                $tot_p_ss,
+                number_format($tot_p_hs, 1, ',', '') . ' h',
+            ),
+            array('left', 'center', 'center', 'center', 'center')
+        );
 
         $pdf = new TCPDF('L', 'mm', 'A4', true, 'UTF-8', false);
         $pdf->SetCreator($nom_club);
@@ -560,14 +560,16 @@ class Formation_rapports extends MY_Controller
 
     /**
      * Génère le HTML d'un tableau de section pour export_annuel_pdf()
-     * (cellules déjà formatées/échappées par l'appelant).
+     * (cellules déjà formatées/échappées par l'appelant, sauf $headers).
      *
-     * @param string $title   Titre de section (avec effectif entre parenthèses)
-     * @param array  $headers En-têtes de colonnes
-     * @param array  $rows    Lignes, chacune un tableau de cellules HTML
+     * @param string     $title   Titre de section (avec effectif entre parenthèses)
+     * @param array      $headers En-têtes de colonnes
+     * @param array      $rows    Lignes, chacune un tableau de cellules HTML
+     * @param array|null $totals  Ligne de totaux optionnelle (mêmes colonnes que $headers)
+     * @param array|null $aligns  Alignement optionnel par colonne ('left'/'center'/'right')
      * @return string
      */
-    private function _pdf_section_table($title, array $headers, array $rows)
+    private function _pdf_section_table($title, array $headers, array $rows, array $totals = null, array $aligns = null)
     {
         // page-break-inside:avoid pousse tout le bloc (titre + tableau) sur la
         // page suivante s'il ne tient pas dans l'espace restant, pour ne
@@ -583,14 +585,21 @@ class Formation_rapports extends MY_Controller
 
         $html .= '<table border="1" cellpadding="3" cellspacing="0" style="width:100%;font-size:8pt;">';
         $html .= '<tr style="background-color:#eee;">';
-        foreach ($headers as $h) {
-            $html .= '<th>' . htmlspecialchars($h) . '</th>';
+        foreach ($headers as $i => $h) {
+            $html .= '<th' . (isset($aligns[$i]) ? ' align="' . $aligns[$i] . '"' : '') . '>' . htmlspecialchars($h) . '</th>';
         }
         $html .= '</tr>';
         foreach ($rows as $row) {
             $html .= '<tr>';
-            foreach ($row as $cell) {
-                $html .= '<td>' . $cell . '</td>';
+            foreach ($row as $i => $cell) {
+                $html .= '<td' . (isset($aligns[$i]) ? ' align="' . $aligns[$i] . '"' : '') . '>' . $cell . '</td>';
+            }
+            $html .= '</tr>';
+        }
+        if ($totals !== null) {
+            $html .= '<tr style="background-color:#eee;">';
+            foreach ($totals as $i => $cell) {
+                $html .= '<th' . (isset($aligns[$i]) ? ' align="' . $aligns[$i] . '"' : '') . '>' . $cell . '</th>';
             }
             $html .= '</tr>';
         }

--- a/application/language/dutch/formation_lang.php
+++ b/application/language/dutch/formation_lang.php
@@ -252,7 +252,7 @@ $lang['formation_seance_nature_toutes']               = 'Alle';
 $lang['formation_seance_nb_participants']             = 'Deelnemers';
 
 // Jaarlijkse geconsolideerde rapporten (Fase 3)
-$lang['formation_rapports_annuel_title']           = 'Jaarlijks geconsolideerd rapport';
+$lang['formation_rapports_annuel_title']           = 'Jaarlijks geconsolideerd opleidingsrapport';
 $lang['formation_rapports_annuel_par_instructeur'] = 'Per instructeur';
 $lang['formation_rapports_annuel_par_programme']   = 'Per programma';
 $lang['formation_rapports_annuel_nb_seances_vol']  = 'Vluchtsessies';

--- a/application/language/dutch/formation_lang.php
+++ b/application/language/dutch/formation_lang.php
@@ -122,6 +122,7 @@ $lang['formation_evaluation_commentaire'] = 'Opmerking';
 
 // Rapporten
 $lang['formation_rapports_title'] = 'Opleidingsrapporten';
+$lang['formation_rapports_section_active'] = 'Sectie';
 $lang['formation_rapports_cloturees_succes'] = 'Succesvol afgeronde opleidingen';
 $lang['formation_rapports_abandonnees'] = 'Afgebroken opleidingen';
 $lang['formation_rapports_suspendues'] = 'Opgeschorte opleidingen';
@@ -262,6 +263,8 @@ $lang['formation_rapports_annuel_nb_eleves_vol']   = 'Vluchtstudenten';
 $lang['formation_rapports_annuel_nb_eleves_sol']   = 'Grondstudenten';
 $lang['formation_rapports_annuel_total']           = 'Totaal';
 $lang['formation_rapports_annuel_export_csv']      = 'CSV exporteren';
+$lang['formation_rapports_annuel_export_pdf']      = 'PDF exporteren';
+$lang['formation_rapports_annuel_genere_le']       = 'Gegenereerd op';
 $lang['formation_rapports_annuel_aucun']           = 'Geen gegevens voor dit jaar.';
 
 // Conformiteitsrapport

--- a/application/language/english/formation_lang.php
+++ b/application/language/english/formation_lang.php
@@ -122,6 +122,7 @@ $lang['formation_evaluation_commentaire'] = 'Comment';
 
 // Reports
 $lang['formation_rapports_title'] = 'Training reports';
+$lang['formation_rapports_section_active'] = 'Section';
 $lang['formation_rapports_cloturees_succes'] = 'Successfully completed trainings';
 $lang['formation_rapports_abandonnees'] = 'Abandoned trainings';
 $lang['formation_rapports_suspendues'] = 'Suspended trainings';
@@ -262,6 +263,8 @@ $lang['formation_rapports_annuel_nb_eleves_vol']   = 'Flight students';
 $lang['formation_rapports_annuel_nb_eleves_sol']   = 'Ground students';
 $lang['formation_rapports_annuel_total']           = 'Total';
 $lang['formation_rapports_annuel_export_csv']      = 'Export CSV';
+$lang['formation_rapports_annuel_export_pdf']      = 'Export PDF';
+$lang['formation_rapports_annuel_genere_le']       = 'Generated on';
 $lang['formation_rapports_annuel_aucun']           = 'No data for this year.';
 
 // Compliance report

--- a/application/language/english/formation_lang.php
+++ b/application/language/english/formation_lang.php
@@ -252,7 +252,7 @@ $lang['formation_seance_nature_toutes']               = 'All';
 $lang['formation_seance_nb_participants']             = 'Participants';
 
 // Annual consolidated reports (Phase 3)
-$lang['formation_rapports_annuel_title']           = 'Annual Consolidated Report';
+$lang['formation_rapports_annuel_title']           = 'Annual Consolidated Training Report';
 $lang['formation_rapports_annuel_par_instructeur'] = 'By instructor';
 $lang['formation_rapports_annuel_par_programme']   = 'By programme';
 $lang['formation_rapports_annuel_nb_seances_vol']  = 'Flight sessions';

--- a/application/language/french/formation_lang.php
+++ b/application/language/french/formation_lang.php
@@ -376,7 +376,7 @@ $lang['formation_seance_nature_toutes']               = 'Toutes';
 $lang['formation_seance_nb_participants']             = 'Participants';
 
 // Rapports annuels consolidés (Phase 3)
-$lang['formation_rapports_annuel_title']           = 'Rapport annuel consolidé';
+$lang['formation_rapports_annuel_title']           = 'Rapport de formation annuel consolidé';
 $lang['formation_rapports_annuel_par_instructeur'] = 'Par instructeur';
 $lang['formation_rapports_annuel_par_programme']   = 'Par programme';
 $lang['formation_rapports_annuel_nb_seances_vol']  = 'Séances vol';

--- a/application/language/french/formation_lang.php
+++ b/application/language/french/formation_lang.php
@@ -256,6 +256,7 @@ $lang['formation_progression_historique'] = 'Historique';
 
 // Rapports
 $lang['formation_rapports_title'] = 'Rapports de formation';
+$lang['formation_rapports_section_active'] = 'Section';
 $lang['formation_rapports_cloturees_succes'] = 'Formations clôturées avec succès';
 $lang['formation_rapports_abandonnees'] = 'Formations abandonnées';
 $lang['formation_rapports_suspendues'] = 'Formations suspendues';
@@ -375,7 +376,7 @@ $lang['formation_seance_nature_toutes']               = 'Toutes';
 $lang['formation_seance_nb_participants']             = 'Participants';
 
 // Rapports annuels consolidés (Phase 3)
-$lang['formation_rapports_annuel_title']           = 'Rapport annuel consolidé';
+$lang['formation_rapports_annuel_title']           = 'Rapport de formation annuel consolidé';
 $lang['formation_rapports_annuel_par_instructeur'] = 'Par instructeur';
 $lang['formation_rapports_annuel_par_programme']   = 'Par programme';
 $lang['formation_rapports_annuel_nb_seances_vol']  = 'Séances vol';
@@ -386,6 +387,8 @@ $lang['formation_rapports_annuel_nb_eleves_vol']   = 'Élèves vol';
 $lang['formation_rapports_annuel_nb_eleves_sol']   = 'Élèves sol';
 $lang['formation_rapports_annuel_total']           = 'Total';
 $lang['formation_rapports_annuel_export_csv']      = 'Exporter CSV';
+$lang['formation_rapports_annuel_export_pdf']      = 'Exporter PDF';
+$lang['formation_rapports_annuel_genere_le']       = 'Généré le';
 $lang['formation_rapports_annuel_aucun']           = 'Aucune donnée pour cette année.';
 
 // Rapport de conformité

--- a/application/language/french/formation_lang.php
+++ b/application/language/french/formation_lang.php
@@ -376,7 +376,7 @@ $lang['formation_seance_nature_toutes']               = 'Toutes';
 $lang['formation_seance_nb_participants']             = 'Participants';
 
 // Rapports annuels consolidés (Phase 3)
-$lang['formation_rapports_annuel_title']           = 'Rapport de formation annuel consolidé';
+$lang['formation_rapports_annuel_title']           = 'Rapport annuel consolidé';
 $lang['formation_rapports_annuel_par_instructeur'] = 'Par instructeur';
 $lang['formation_rapports_annuel_par_programme']   = 'Par programme';
 $lang['formation_rapports_annuel_nb_seances_vol']  = 'Séances vol';

--- a/application/models/formation_seance_model.php
+++ b/application/models/formation_seance_model.php
@@ -784,12 +784,13 @@ class Formation_seance_model extends Common_Model {
      * @return array
      */
     public function get_stats_annuels_par_instructeur($year) {
-        // Séances VOL
+        // Séances VOL déclarées : nombre et élèves. Les heures de vol sont
+        // calculées depuis volsa (voir get_stats_dc_par_instructeur ci-dessous),
+        // pas depuis la durée déclarée de la séance.
         $sql_vol = "
             SELECT s.instructeur_id,
                    inst.mnom AS instructeur_nom, inst.mprenom AS instructeur_prenom,
                    COUNT(*) AS nb_seances_vol,
-                   ROUND(SUM(COALESCE(TIME_TO_SEC(s.duree), 0)) / 3600, 2) AS heures_vol,
                    COUNT(DISTINCT s.pilote_id) AS nb_eleves_vol
             FROM {$this->table} s
             LEFT JOIN membres inst ON s.instructeur_id = inst.mlogin
@@ -818,6 +819,22 @@ class Formation_seance_model extends Common_Model {
         $rows_vol = $this->db->query($sql_vol, array((int)$year))->result_array();
         $rows_sol = $this->db->query($sql_sol, array((int)$year))->result_array();
 
+        // Heures et vols d'instruction (volsa, vadc = 1), toutes séances
+        // confondues (déclarées ou non) : c'est la source des heures de vol.
+        $rows_dc = $this->get_stats_dc_par_instructeur($year);
+
+        // Vols DC sans séance déclarée : un vol DC = une séance, donc ils
+        // s'ajoutent au nombre de séances de vol déclarées.
+        $rows_dc_sans_seance = $this->get_vols_dc_sans_seance($year);
+        $nb_orphelines = array();
+        foreach ($rows_dc_sans_seance as $r) {
+            $iid = $r['instructeur_id'];
+            if (!isset($nb_orphelines[$iid])) {
+                $nb_orphelines[$iid] = 0;
+            }
+            $nb_orphelines[$iid] += (int) $r['nb_vols'];
+        }
+
         $stats = array();
 
         foreach ($rows_vol as $r) {
@@ -826,7 +843,6 @@ class Formation_seance_model extends Common_Model {
                 $stats[$id] = $this->_make_instructor_stats($id, $r['instructeur_nom'], $r['instructeur_prenom']);
             }
             $stats[$id]['nb_seances_vol'] = (int)$r['nb_seances_vol'];
-            $stats[$id]['heures_vol']     = (float)$r['heures_vol'];
             $stats[$id]['nb_eleves_vol']  = (int)$r['nb_eleves_vol'];
         }
 
@@ -838,6 +854,23 @@ class Formation_seance_model extends Common_Model {
             $stats[$id]['nb_seances_sol'] = (int)$r['nb_seances_sol'];
             $stats[$id]['heures_sol']     = (float)$r['heures_sol'];
             $stats[$id]['nb_eleves_sol']  = (int)$r['nb_eleves_sol'];
+        }
+
+        foreach ($rows_dc as $r) {
+            $id = $r['instructeur_id'];
+            if (!isset($stats[$id])) {
+                $stats[$id] = $this->_make_instructor_stats($id, $r['instructeur_nom'], $r['instructeur_prenom']);
+            }
+            $stats[$id]['heures_vol'] = (float) $r['heures'];
+        }
+
+        foreach ($nb_orphelines as $id => $nb) {
+            if (!isset($stats[$id])) {
+                // Cas théorique : un vol DC sans séance déclarée existe
+                // forcément aussi dans $rows_dc, qui a déjà créé l'entrée.
+                $stats[$id] = $this->_make_instructor_stats($id, '', '');
+            }
+            $stats[$id]['nb_seances_vol'] += $nb;
         }
 
         // Sort by instructor name

--- a/application/views/formation_rapports/annuel.php
+++ b/application/views/formation_rapports/annuel.php
@@ -15,6 +15,10 @@ $this->load->view('bs_banner');
         <h3>
             <i class="fas fa-chart-line" aria-hidden="true"></i>
             <?= $this->lang->line('formation_rapports_annuel_title') ?>
+            <span class="badge bg-secondary align-middle" style="font-size: 0.5em;">
+                <i class="fas fa-layer-group" aria-hidden="true"></i>
+                <?= $this->lang->line("formation_rapports_section_active") ?> : <?= htmlspecialchars($section_active_label) ?>
+            </span>
         </h3>
         <div class="d-flex align-items-center gap-3">
             <?= year_selector('formation_rapports/new_year_annuel', $year, $year_selector) ?>
@@ -22,6 +26,11 @@ $this->load->view('bs_banner');
                class="btn btn-outline-success btn-sm">
                 <i class="fas fa-file-csv" aria-hidden="true"></i>
                 <?= $this->lang->line('formation_rapports_annuel_export_csv') ?>
+            </a>
+            <a href="<?= controller_url($controller) ?>/export_annuel_pdf/<?= $year ?>"
+               class="btn btn-outline-danger btn-sm">
+                <i class="fas fa-file-pdf" aria-hidden="true"></i>
+                <?= $this->lang->line('formation_rapports_annuel_export_pdf') ?>
             </a>
             <a href="<?= controller_url($controller) ?>" class="btn btn-outline-secondary btn-sm">
                 <i class="fas fa-arrow-left" aria-hidden="true"></i>

--- a/application/views/formation_rapports/index.php
+++ b/application/views/formation_rapports/index.php
@@ -24,6 +24,10 @@ $this->load->view('bs_banner');
         <h3>
             <i class="fas fa-chart-bar" aria-hidden="true"></i>
             <?= $this->lang->line("formation_rapports_title") ?>
+            <span class="badge bg-secondary align-middle" style="font-size: 0.5em;">
+                <i class="fas fa-layer-group" aria-hidden="true"></i>
+                <?= $this->lang->line("formation_rapports_section_active") ?> : <?= htmlspecialchars($section_active_label) ?>
+            </span>
         </h3>
         <div class="d-flex align-items-center gap-3">
             <?= year_selector('formation_rapports', $year, $year_selector) ?>


### PR DESCRIPTION
## Résumé

- **`formation_rapports/annuel`** : les heures de vol et le nombre de séances de l'onglet "par instructeur" comptent désormais les vols DC (`volsa`, `vadc=1`) qui n'ont pas donné lieu à la déclaration d'une `formation_seances` (rapprochement heuristique date/pilote/instructeur), pas uniquement les séances déclarées.
- **Export PDF** du rapport annuel (`export_annuel_pdf`) : reprend les 5 listes de formations (clôturées, abandonnées, suspendues, ouvertes, en cours avec % de progression) puis les tableaux "par instructeur"/"par programme", avec une mise en page qui évite qu'un titre de section soit séparé de son tableau par un saut de page (`page-break-inside:avoid`).
- **Section active** : affichée en badge sur les pages HTML (`formation_rapports`, `formation_rapports/annuel`) et sur le PDF, pour que l'utilisateur sache toujours quelles données il regarde. `formation_rapports/conformite` n'a pas été modifiée (son modèle ne filtre pas par section).
- **Correction d'un bug de filtrage par section** dans `formation_seance_model.php` : les séances/vols sans machine renseignée passaient le filtre de section (bypass `machine_id IS NULL OR ...`) et apparaissaient à tort dans n'importe quelle section. Le filtre se base désormais uniquement sur la section de la machine ; sans machine, la séance n'apparaît que dans la vue "Toutes".

## Test plan

- [x] `php -l` sur tous les fichiers modifiés
- [x] `vendor/bin/phpunit -c phpunit_mysql.xml application/tests/mysql/` : 919 tests, 0 échec (30 skips pré-existants, inchangé)
- [x] Vérification manuelle sur gvv.net (via curl + session admin `panoramix`) : filtrage par section correct (bug Lodigeois/Planeur et Peignot/Avion résolus), export PDF cohérent avec les pages HTML, badge de section correct pour "Planeur" et "Toutes"
- [x] PDF : vérifié page par page (`pdftotext`) qu'aucun titre de section n'est séparé de son tableau

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GA4CS2Mfjad8zEcjdT9Zs6